### PR TITLE
Add Generator property to csproj files

### DIFF
--- a/src/CoreBlog.Data.Abstractions/CoreBlog.Data.Abstractions.csproj
+++ b/src/CoreBlog.Data.Abstractions/CoreBlog.Data.Abstractions.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UseNETCoreGenerator>true</UseNETCoreGenerator>
   </PropertyGroup>
 
 </Project>

--- a/src/CoreBlog.Data.EntityFramework/CoreBlog.Data.EntityFramework.csproj
+++ b/src/CoreBlog.Data.EntityFramework/CoreBlog.Data.EntityFramework.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UseNETCoreGenerator>true</UseNETCoreGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CoreBlog.GrainClientServices.Abstractions/CoreBlog.GrainClientServices.Abstractions.csproj
+++ b/src/CoreBlog.GrainClientServices.Abstractions/CoreBlog.GrainClientServices.Abstractions.csproj
@@ -6,6 +6,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UseNETCoreGenerator>true</UseNETCoreGenerator>
   </PropertyGroup>
 
 </Project>

--- a/src/CoreBlog.GrainClientServices/CoreBlog.GrainClientServices.csproj
+++ b/src/CoreBlog.GrainClientServices/CoreBlog.GrainClientServices.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UseNETCoreGenerator>true</UseNETCoreGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CoreBlog.GrainModels/CoreBlog.GrainModels.csproj
+++ b/src/CoreBlog.GrainModels/CoreBlog.GrainModels.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UseNETCoreGenerator>true</UseNETCoreGenerator>
   </PropertyGroup>
 
 </Project>

--- a/src/CoreBlog.Grains.Abstractions/CoreBlog.Grains.Abstractions.csproj
+++ b/src/CoreBlog.Grains.Abstractions/CoreBlog.Grains.Abstractions.csproj
@@ -14,6 +14,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UseNETCoreGenerator>true</UseNETCoreGenerator>
   </PropertyGroup>
 
 </Project>

--- a/src/CoreBlog.Grains/CoreBlog.Grains.csproj
+++ b/src/CoreBlog.Grains/CoreBlog.Grains.csproj
@@ -16,6 +16,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UseNETCoreGenerator>true</UseNETCoreGenerator>
   </PropertyGroup>
 
 </Project>

--- a/src/CoreBlog.GraphQL/CoreBlog.GraphQL.csproj
+++ b/src/CoreBlog.GraphQL/CoreBlog.GraphQL.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UseNETCoreGenerator>true</UseNETCoreGenerator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CoreBlog.SiloHost/CoreBlog.SiloHost.csproj
+++ b/src/CoreBlog.SiloHost/CoreBlog.SiloHost.csproj
@@ -33,6 +33,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UseNETCoreGenerator>true</UseNETCoreGenerator>
   </PropertyGroup>
 
 </Project>

--- a/src/CoreBlog.WebApi/CoreBlog.WebApi.csproj
+++ b/src/CoreBlog.WebApi/CoreBlog.WebApi.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <UseNETCoreGenerator>true</UseNETCoreGenerator>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 


### PR DESCRIPTION
Azure DevOps build pipeline fails due to OrleansCodeGenerator not being
able to load the right version of System.Runtime. This commit tries to
fix that issue.