### PR TITLE
Replace Orleans Code Generator

### DIFF
--- a/src/CoreBlog.Grains.Abstractions/CoreBlog.Grains.Abstractions.csproj
+++ b/src/CoreBlog.Grains.Abstractions/CoreBlog.Grains.Abstractions.csproj
@@ -6,10 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.2.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/CoreBlog.Grains/CoreBlog.Grains.csproj
+++ b/src/CoreBlog.Grains/CoreBlog.Grains.csproj
@@ -8,10 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Core" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.2.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/CoreBlog.SiloHost/CoreBlog.SiloHost.csproj
+++ b/src/CoreBlog.SiloHost/CoreBlog.SiloHost.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.2.0">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CoreBlog.SiloHost/Program.cs
+++ b/src/CoreBlog.SiloHost/Program.cs
@@ -7,9 +7,13 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Logging;
 using Orleans;
+using Orleans.CodeGeneration;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using IHostingEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
+
+[assembly: KnownAssembly(typeof(CoreBlog.Grains.Abstractions.Posts.IBlogPostGrain))]
+[assembly: KnownAssembly(typeof(CoreBlog.Grains.Posts.BlogPostGrain))]
 
 namespace CoreBlog.SiloHost {
     using Data.EntityFramework;

--- a/src/CoreBlog.WebApi/CoreBlog.WebApi.csproj
+++ b/src/CoreBlog.WebApi/CoreBlog.WebApi.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Orleans.Client" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.2.0">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CoreBlog.WebApi/Program.cs
+++ b/src/CoreBlog.WebApi/Program.cs
@@ -7,6 +7,10 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Orleans.CodeGeneration;
+
+[assembly: KnownAssembly(typeof(CoreBlog.GrainClientServices.BlogPostService))]
+[assembly: KnownAssembly(typeof(CoreBlog.Grains.Abstractions.Posts.IBlogPostGrain))]
 
 namespace CoreBlog.WebApi
 {


### PR DESCRIPTION
Replaces Microsoft.Orleans.OrleansCodeGenerator.Build with
Microsoft.Orleans.CodeGenerator.MSBuild in order to hopefully avoid the
clashing dependencies issue in Azure DevOps.