### PR TITLE
Add GrainClientServices Tests

### DIFF
--- a/CoreBlog.sln
+++ b/CoreBlog.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreBlog.Data.Abstractions.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreBlog.Grains.Tests", "tests\CoreBlog.Grains.Tests\CoreBlog.Grains.Tests.csproj", "{08F8FA83-AF5C-4C94-A1B6-84D98678CFF0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreBlog.GrainClientServices.Tests", "tests\CoreBlog.GrainClientServices.Tests\CoreBlog.GrainClientServices.Tests.csproj", "{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -199,6 +201,18 @@ Global
 		{08F8FA83-AF5C-4C94-A1B6-84D98678CFF0}.Release|x64.Build.0 = Release|Any CPU
 		{08F8FA83-AF5C-4C94-A1B6-84D98678CFF0}.Release|x86.ActiveCfg = Release|Any CPU
 		{08F8FA83-AF5C-4C94-A1B6-84D98678CFF0}.Release|x86.Build.0 = Release|Any CPU
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}.Debug|x64.Build.0 = Debug|Any CPU
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}.Debug|x86.Build.0 = Debug|Any CPU
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}.Release|x64.ActiveCfg = Release|Any CPU
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}.Release|x64.Build.0 = Release|Any CPU
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}.Release|x86.ActiveCfg = Release|Any CPU
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -217,6 +231,7 @@ Global
 		{5221AC1E-DCF0-4E4D-BEC8-45F70A613172} = {D4A5C672-3385-4E59-8492-3D4D285E7409}
 		{76C9D2E2-1B98-403B-8600-0341FBF2D76D} = {D4A5C672-3385-4E59-8492-3D4D285E7409}
 		{08F8FA83-AF5C-4C94-A1B6-84D98678CFF0} = {D4A5C672-3385-4E59-8492-3D4D285E7409}
+		{5B36A4D3-54D1-41F8-94F6-477DE6CCD0CE} = {D4A5C672-3385-4E59-8492-3D4D285E7409}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C7986623-B7BF-4591-9111-B84CBAAD412A}

--- a/tests/CoreBlog.GrainClientServices.Tests/BlogPostServiceTests.cs
+++ b/tests/CoreBlog.GrainClientServices.Tests/BlogPostServiceTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading.Tasks;
+using CoreBlog.GrainClientServices;
+using CoreBlog.GrainModels.Posts;
+using CoreBlog.Grains.Abstractions.Posts;
+using FluentAssertions;
+using Moq;
+using Orleans;
+using Xunit;
+
+namespace CoreBlog.GrainClientServices.Tests {
+    public class BlogPostServiceTests {
+        private readonly BlogPostService _blogPostService;
+        private Mock<IClusterClient> _clusterClient;
+
+        public BlogPostServiceTests() {
+            _clusterClient = new Mock<IClusterClient>();
+
+            _blogPostService = new BlogPostService(_clusterClient.Object);
+        }
+
+        [Fact] public void GetPostByIdAsync_ShouldContactBlogPostGrain() {
+            var postGrain = new Mock<IBlogPostGrain>();
+            
+            var post = new BlogPost { BlogPostId = Guid.NewGuid() };
+
+            _clusterClient.Setup(c => c.GetGrain<IBlogPostGrain>(post.BlogPostId, null))
+                .Returns(() => postGrain.Object);
+
+            postGrain.Setup(g => g.Find()).Returns(() => Task.FromResult(post));
+
+            _blogPostService.GetPostByIdAsync(post.BlogPostId).GetAwaiter().GetResult()
+                .Should().Be(post, "because that's what we requested");
+
+            _clusterClient.Verify(c => c.GetGrain<IBlogPostGrain>(post.BlogPostId, null), Times.Once(),
+                "because we need to fetch the grain");
+
+            postGrain.Verify(g => g.Find(), Times.Once(),
+                "because we need to fetch the post");
+
+            _clusterClient.VerifyNoOtherCalls();
+            postGrain.VerifyNoOtherCalls();
+        }
+
+        [Fact] public void GetPostById_ShouldContactBlogPostGrain() {
+            var postGrain = new Mock<IBlogPostGrain>();
+
+            var post = new BlogPost { BlogPostId = Guid.NewGuid() };
+
+            _clusterClient.Setup(c => c.GetGrain<IBlogPostGrain>(post.BlogPostId, null))
+                .Returns(() => postGrain.Object);
+
+            postGrain.Setup(g => g.Find()).Returns(() => Task.FromResult(post));
+
+            _blogPostService.GetPostById(post.BlogPostId)
+                .Should().Be(post, "because that's what we requested");
+
+            _clusterClient.Verify(c => c.GetGrain<IBlogPostGrain>(post.BlogPostId, null), Times.Once(),
+                "because we need to fetch the grain");
+
+            postGrain.Verify(g => g.Find(), Times.Once(),
+                "because we need to fetch the post");
+
+            _clusterClient.VerifyNoOtherCalls();
+            postGrain.VerifyNoOtherCalls();
+        }
+
+        [Fact] public void CreatePost_ShouldCallAddOnRegistryGrain() {
+            var postGrain = new Mock<IBlogPostRegistryGrain>();
+
+            var postId = Guid.NewGuid();
+            var post = new BlogPost { };
+
+            _clusterClient.Setup(c => c.GetGrain<IBlogPostRegistryGrain>(0, null))
+                .Returns(() => postGrain.Object);
+
+            postGrain.Setup(g => g.Add(post)).Returns(() => Task.FromResult(postId));
+
+            _blogPostService.CreatePost(post).GetAwaiter().GetResult()
+                .Should().Be(postId, "because that's what the grain returns");
+
+            _clusterClient.Verify(c => c.GetGrain<IBlogPostRegistryGrain>(0, null), Times.Once,
+                "because we only need one instance of the grain");
+
+            postGrain.Verify(g => g.Add(post), Times.Once(), "because we only want to create it once");
+        }
+    }
+}

--- a/tests/CoreBlog.GrainClientServices.Tests/CoreBlog.GrainClientServices.Tests.csproj
+++ b/tests/CoreBlog.GrainClientServices.Tests/CoreBlog.GrainClientServices.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\CoreBlog.GrainClientServices\CoreBlog.GrainClientServices.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CoreBlog.GrainClientServices.Tests/UserServiceTests.cs
+++ b/tests/CoreBlog.GrainClientServices.Tests/UserServiceTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using CoreBlog.GrainModels.Users;
+using CoreBlog.Grains.Abstractions.Users;
+using FluentAssertions;
+using Moq;
+using Orleans;
+using Xunit;
+
+namespace CoreBlog.GrainClientServices.Tests {
+    public class UserServiceTests {
+        private readonly UserService _userService;
+        private Mock<IClusterClient> _clusterClient;
+
+        public UserServiceTests() {
+            _clusterClient = new Mock<IClusterClient>();
+
+            _userService = new UserService(_clusterClient.Object);
+        }
+
+        [Fact] public void Find_ShouldGetUserFromUserGrain() {
+            var postGrain = new Mock<IUserGrain>();
+
+            var user = new User { UserId = Guid.NewGuid() };
+
+            _clusterClient.Setup(c => c.GetGrain<IUserGrain>(user.UserId, null))
+                .Returns(() => postGrain.Object);
+
+            postGrain.Setup(g => g.Find()).Returns(() => Task.FromResult(user));
+
+            _userService.Find(user.UserId)
+                .Should().Be(user, "because that's what we requested");
+
+            _clusterClient.Verify(c => c.GetGrain<IUserGrain>(user.UserId, null), Times.Once(),
+                "because we need to fetch the grain");
+
+            postGrain.Verify(g => g.Find(), Times.Once(),
+                "because we need to fetch the user");
+
+            _clusterClient.VerifyNoOtherCalls();
+            postGrain.VerifyNoOtherCalls();
+
+        }
+
+        [Fact] public void FindAsync_ShouldGetUserFromUserGrain() {
+            var postGrain = new Mock<IUserGrain>();
+
+            var user = new User { UserId = Guid.NewGuid() };
+
+            _clusterClient.Setup(c => c.GetGrain<IUserGrain>(user.UserId, null))
+                .Returns(() => postGrain.Object);
+
+            postGrain.Setup(g => g.Find()).Returns(() => Task.FromResult(user));
+
+            _userService.FindAsync(user.UserId).GetAwaiter().GetResult()
+                .Should().Be(user, "because that's what we requested");
+
+            _clusterClient.Verify(c => c.GetGrain<IUserGrain>(user.UserId, null), Times.Once(),
+                "because we need to fetch the grain");
+
+            postGrain.Verify(g => g.Find(), Times.Once(),
+                "because we need to fetch the user");
+
+            _clusterClient.VerifyNoOtherCalls();
+            postGrain.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/tests/CoreBlog.Grains.Tests/Posts/BlogPostModelExtensionMethods.cs
+++ b/tests/CoreBlog.Grains.Tests/Posts/BlogPostModelExtensionMethods.cs
@@ -24,8 +24,8 @@ namespace CoreBlog.Grains.Tests.Posts {
 
         [Fact]
         public void ToDataModel_ShouldTransferAllFields() {
-            var expectation = new IncomingBlogPost();
             var original = new BlogPost();
+            var expectation = new IncomingBlogPost();
 
             original.BlogPostId = expectation.BlogPostId = Guid.NewGuid();
             original.Title = expectation.Title = "Hello, world!";


### PR DESCRIPTION
Retroactively add tests for the CoreBlog.GrainClientServices project.